### PR TITLE
Fix 'check_satpy' import

### DIFF
--- a/notebooks/01_introduction.ipynb
+++ b/notebooks/01_introduction.ipynb
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from satpy.config import check_satpy\n",
+    "from satpy.utils import check_satpy\n",
     "check_satpy(readers=['abi_l1b', 'viirs_sdr'],\n",
     "            writers=['geotiff', 'cf', 'simple_image'],\n",
     "            extras=['cartopy', 'geoviews'])"

--- a/test_install.py
+++ b/test_install.py
@@ -11,7 +11,7 @@ import os
 from contextlib import redirect_stdout
 
 try:
-    from satpy.config import check_satpy
+    from satpy.utils import check_satpy
 except ImportError:
     print("FAIL: Satpy is not importable")
     raise


### PR DESCRIPTION
Closes #8.

The `check_satpy` function has been moved to `satpy.utils`.